### PR TITLE
regarde 1.2.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 // Dependencies
 var Ul = require("ul")
   , Exec = require("child_process").exec
+  , typpy = require("typpy")
   ;
 
 /**
@@ -21,7 +22,7 @@ var Ul = require("ul")
  */
 var Regarde = module.exports = function (cmd, interval, out) {
 
-    if (this.constructor !== Regarde) {
+    if (!typpy(this, Regarde)) {
         return new Regarde(cmd, interval, out);
     }
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   },
   "dependencies": {
     "bug-killer": "^1.0.0",
-    "yargs": "^3.0.4",
-    "ul": "^1.1.0"
+    "typpy": "^2.3.3",
+    "ul": "^1.1.0",
+    "yargs": "^3.0.4"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regarde",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A tiny tool and library to watch commands.",
   "main": "lib/index.js",
   "bin": "./bin/regarde",


### PR DESCRIPTION
Fix a bug that appears in strict mode.

`this` is undefined when not calling the function using `new`, so use `typpy` to check if the context is a current instance, otherwise, create one. :boom:
